### PR TITLE
Targeting now seperate

### DIFF
--- a/Tower/AsciiRogue/Assets/Items/ScrollSO.cs
+++ b/Tower/AsciiRogue/Assets/Items/ScrollSO.cs
@@ -1,7 +1,7 @@
 ﻿using UnityEngine;
 
 [CreateAssetMenu(menuName = "Items/Scroll")]
-public class ScrollSO : ItemScriptableObject
+public class ScrollSO : ItemScriptableObject,IRestrictTargeting
 {
     public enum school
     {
@@ -55,7 +55,8 @@ public class ScrollSO : ItemScriptableObject
             {
                 player.usedScrollOrBook = this;
                 player.usingSpellScroll = true;
-                player.spell_pos = MapManager.playerPos;
+
+                Targeting.IsTargeting = true;
             }
 
             GameManager.manager.CloseEQ();
@@ -122,10 +123,10 @@ public class ScrollSO : ItemScriptableObject
     {
         if(foo is PlayerStats player)
         {
-            if(MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy != null)
+            if(MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy != null)
             {
-                MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy.GetComponent<RoamingNPC>().dotDuration = spellDuration;
-                MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy.GetComponent<RoamingNPC>().DamageOverTurn();            
+                MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy.GetComponent<RoamingNPC>().dotDuration = spellDuration;
+                MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy.GetComponent<RoamingNPC>().DamageOverTurn();            
                 GameManager.manager.ApplyChangesInInventory(this);   
                 GameManager.manager.UpdateMessages("You read the <color=red>Scroll of Poison Bolt</color>. Monster is now poisoned.");
             }
@@ -136,10 +137,10 @@ public class ScrollSO : ItemScriptableObject
     {
         if(foo is PlayerStats player)
         {
-            if(MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy != null)
+            if(MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy != null)
             {
-                 MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy.GetComponent<RoamingNPC>().rooted = true;
-                 MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy.GetComponent<RoamingNPC>().rootDuration = 10 + Mathf.FloorToInt(player.__intelligence / 10);
+                 MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy.GetComponent<RoamingNPC>().rooted = true;
+                 MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy.GetComponent<RoamingNPC>().rootDuration = 10 + Mathf.FloorToInt(player.__intelligence / 10);
                  GameManager.manager.ApplyChangesInInventory(this);   
                  GameManager.manager.UpdateMessages("You read the <color=red>Scroll of Root</color>. This monster can't move now.");
             }
@@ -161,9 +162,9 @@ public class ScrollSO : ItemScriptableObject
     {
         if(foo is PlayerStats player)
         {
-            if(MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy != null)
+            if(MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy != null)
             {               
-                MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy.GetComponent<RoamingNPC>().TakeDamage(Mathf.FloorToInt((20 + player.__intelligence) / 5));
+                MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy.GetComponent<RoamingNPC>().TakeDamage(Mathf.FloorToInt((20 + player.__intelligence) / 5));
                 player.TakeDamage(5);
                 Debug.Log("Blood purge" + Mathf.FloorToInt((20 + player.__intelligence) / 5));
                 GameManager.manager.ApplyChangesInInventory(this);   
@@ -238,9 +239,9 @@ public class ScrollSO : ItemScriptableObject
     {
         if(foo is PlayerStats player)
         {
-            if(MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy != null)
+            if(MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy != null)
             {
-                MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy.GetComponent<RoamingNPC>().TakeDamage(10 + Mathf.FloorToInt(player.__intelligence / 7));
+                MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy.GetComponent<RoamingNPC>().TakeDamage(10 + Mathf.FloorToInt(player.__intelligence / 7));
                 GameManager.manager.ApplyChangesInInventory(this);   
                 GameManager.manager.UpdateMessages($"You read the <color=green>Scroll of Poison Dart.</color> You dealt {10 + Mathf.FloorToInt(player.__intelligence / 7)} damage to the monster.");
             }
@@ -282,5 +283,17 @@ public class ScrollSO : ItemScriptableObject
 
     public override void onUnequip(MonoBehaviour foo)
     {
+    }
+
+    public bool IsValidTarget()
+    {
+        // TODO: code is required here
+        return true;
+    }
+
+    public bool AllowTargeting()
+    {
+        // TODO: code is required here
+        return true;
     }
 }

--- a/Tower/AsciiRogue/Assets/Items/SpellbookSO.cs
+++ b/Tower/AsciiRogue/Assets/Items/SpellbookSO.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 [CreateAssetMenu(menuName = "Items/Spellbook")]
-public class SpellbookSO : ItemScriptableObject
+public class SpellbookSO : ItemScriptableObject,IRestrictTargeting
 {
     public enum school
     {
@@ -104,7 +104,7 @@ public class SpellbookSO : ItemScriptableObject
             {
                 player.usedScrollOrBook = this;
                 player.usingSpellScroll = true;
-                player.spell_pos = MapManager.playerPos;
+                Targeting.IsTargeting = true;
             }
 
             GameManager.manager.CloseEQ();
@@ -162,9 +162,9 @@ public class SpellbookSO : ItemScriptableObject
 
         if(foo is PlayerStats _player)
         {
-            if (MapManager.map[_player.spell_pos.x, _player.spell_pos.y].enemy != null)
+            if (MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy != null)
             {
-                MapManager.map[_player.spell_pos.x, _player.spell_pos.y].enemy.GetComponent<RoamingNPC>().WakeUp();
+                MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy.GetComponent<RoamingNPC>().WakeUp();
             }
         }
     }
@@ -173,10 +173,10 @@ public class SpellbookSO : ItemScriptableObject
     {
         if(foo is PlayerStats player)
         {
-            if(MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy != null)
+            if(MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy != null)
             {
                 int damage = Random.Range(1, 10) + Random.Range(1, 10) + player.__intelligence / 10;
-                MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy.GetComponent<RoamingNPC>().TakeDamage(damage);
+                MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy.GetComponent<RoamingNPC>().TakeDamage(damage);
                 item.spellbookCooldown = 20;
                 GameManager.manager.UpdateMessages($"You read the <color=red>Book of Drain Life</color>. You drained <color=red>{damage}</color> health.");
             }
@@ -187,10 +187,10 @@ public class SpellbookSO : ItemScriptableObject
     {
         if(foo is PlayerStats player)
         {
-            if(MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy != null)
+            if(MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy != null)
             {
-                MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy.GetComponent<RoamingNPC>().dotDuration = spellDuration;
-                MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy.GetComponent<RoamingNPC>().DamageOverTurn(); 
+                MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy.GetComponent<RoamingNPC>().dotDuration = spellDuration;
+                MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy.GetComponent<RoamingNPC>().DamageOverTurn(); 
                 GameManager.manager.UpdateMessages("You read the <color=red>Book of Poison Bolt</color>. Monster is now poisoned.");
             }
         }
@@ -200,10 +200,10 @@ public class SpellbookSO : ItemScriptableObject
     {
         if(foo is PlayerStats player)
         {
-            if(MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy != null)
+            if(MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy != null)
             {
-                MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy.GetComponent<RoamingNPC>().rooted = true;
-                MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy.GetComponent<RoamingNPC>().rootDuration = 10 + Mathf.FloorToInt(player.__intelligence / 10);  
+                MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy.GetComponent<RoamingNPC>().rooted = true;
+                MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy.GetComponent<RoamingNPC>().rootDuration = 10 + Mathf.FloorToInt(player.__intelligence / 10);  
                 GameManager.manager.UpdateMessages("You read the <color=red>Book of Root</color>. Monster can't move!");
             }
         }
@@ -223,9 +223,9 @@ public class SpellbookSO : ItemScriptableObject
     {
         if(foo is PlayerStats player)
         {
-            if(MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy != null)
+            if(MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy != null)
             {               
-                MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy.GetComponent<RoamingNPC>().TakeDamage(Mathf.FloorToInt((20 + player.__intelligence) / 5));
+                MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy.GetComponent<RoamingNPC>().TakeDamage(Mathf.FloorToInt((20 + player.__intelligence) / 5));
                 player.TakeDamage(5);
                 GameManager.manager.UpdateMessages($"You read the <color=red>Book of Blood for Blood</color>. You dealt {(20 + player.__intelligence) / 5} damage to the monster.");
             }
@@ -290,9 +290,9 @@ public class SpellbookSO : ItemScriptableObject
     {
         if(foo is PlayerStats player)
         {
-            if(MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy != null)
+            if(MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy != null)
             {
-                MapManager.map[player.spell_pos.x, player.spell_pos.y].enemy.GetComponent<RoamingNPC>().TakeDamage(10 + Mathf.FloorToInt(player.__intelligence / 7));
+                MapManager.map[Targeting.Position.x, Targeting.Position.y].enemy.GetComponent<RoamingNPC>().TakeDamage(10 + Mathf.FloorToInt(player.__intelligence / 7));
                 GameManager.manager.UpdateMessages($"You read the <color=green>Book of Poison Dart.</color> You dealt {10 + Mathf.FloorToInt(player.__intelligence / 7)} damage to the monster.");
             }
         }
@@ -326,5 +326,16 @@ public class SpellbookSO : ItemScriptableObject
 
     public override void onUnequip(MonoBehaviour foo)
     {
+    }
+    public bool IsValidTarget()
+    {
+        // TODO: code is required here
+        return true;
+    }
+
+    public bool AllowTargeting()
+    {
+        // TODO: code is required here
+        return true;
     }
 }

--- a/Tower/AsciiRogue/Assets/Items/WandSO.cs
+++ b/Tower/AsciiRogue/Assets/Items/WandSO.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 [CreateAssetMenu(menuName = "Items/Wand")]
-public class WandSO : ItemScriptableObject
+public class WandSO : ItemScriptableObject, IRestrictTargeting
 {
     public int charges;
     [SerializeField] public int chargesLeft;
@@ -29,7 +29,7 @@ public class WandSO : ItemScriptableObject
         if(foo is PlayerStats player && chargesLeft > 0)
         {
             player.usingWand = true;
-            player.wand_pos = MapManager.playerPos;
+            Targeting.IsTargeting = true;
             player.usedWand = this;          
         }
         else if(chargesLeft < 1) //no charges left
@@ -106,5 +106,16 @@ public class WandSO : ItemScriptableObject
 
     public override void onUnequip(MonoBehaviour foo)
     {
+    }
+    public bool IsValidTarget()
+    {
+        // TODO: code is required here
+        return true;
+    }
+
+    public bool AllowTargeting()
+    {
+        // TODO: code is required here
+        return true;
     }
 }

--- a/Tower/AsciiRogue/Assets/Scripts/IRestrictTargeting.cs
+++ b/Tower/AsciiRogue/Assets/Scripts/IRestrictTargeting.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Should be used for the targeting system in order to allow it to revert to older targeting
+/// </summary>
+public interface IRestrictTargeting
+{
+    /// <summary>
+    /// If the current Target is valid
+    /// </summary>
+    /// <returns></returns>
+    bool IsValidTarget();
+    /// <summary>
+    /// if the current position of the targeting system is allowed
+    /// </summary>
+    /// <returns></returns>
+    bool AllowTargeting();
+}

--- a/Tower/AsciiRogue/Assets/Scripts/IRestrictTargeting.cs.meta
+++ b/Tower/AsciiRogue/Assets/Scripts/IRestrictTargeting.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c2265f1e0a8495b47b9de346210e26f6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tower/AsciiRogue/Assets/Scripts/PlayerStats.cs
+++ b/Tower/AsciiRogue/Assets/Scripts/PlayerStats.cs
@@ -423,13 +423,11 @@ public class PlayerStats : MonoBehaviour, ITakeDamage, IPoison, IFireResistance,
 
     //WAND STUFF
     [SerializeField] public bool usingWand;
-    [HideInInspector] public Vector2Int wand_pos;
     [SerializeField] public List<Vector2Int> wand_path;
     [SerializeField] public WandSO usedWand;
 
     //SCROLLS & SPELLBOOKS
     [HideInInspector] public bool usingSpellScroll;
-    [HideInInspector] public Vector2Int spell_pos;
     [HideInInspector] public ItemScriptableObject usedScrollOrBook;
 
     //DIALOGUE
@@ -525,209 +523,125 @@ public class PlayerStats : MonoBehaviour, ITakeDamage, IPoison, IFireResistance,
             __endurance++;
         }
 
+        Targeting.UpdateTargeting();
+
         if (usingWand)
         {
-            if(PlayerMovement.playerMovement.canMove) PlayerMovement.playerMovement.canMove = false;
-            
-            if(usedWand._spellType == WandSO.spellType.ray)
+
+            if (usedWand._spellType == WandSO.spellType.ray)
             {
-                if (Input.GetKeyDown(KeyCode.W) && CellIsAvailable(wand_pos.x, wand_pos.y + 1))
+                if (!usedWand.AllowTargeting())
                 {
-                    wand_pos.y++;
-                    wand_path = LineAlg.GetPointsOnLine(MapManager.playerPos.x, MapManager.playerPos.y, wand_pos.x, wand_pos.y);
-
-                    foreach (var cell in wand_path)
-                    {
-                        MapManager.map[cell.x, cell.y].decoy = $"<color=yellow>\u205C</color>";
-                    }
-
-                    DungeonGenerator.dungeonGenerator.DrawMap(true, MapManager.map);
+                    Targeting.Revert();
                 }
-                else if (Input.GetKeyDown(KeyCode.S) && CellIsAvailable(wand_pos.x, wand_pos.y - 1))
+
+                wand_path = LineAlg.GetPointsOnLine(
+                    MapManager.playerPos.x, MapManager.playerPos.y,
+                    Targeting.Position.x, Targeting.Position.y);
+
+                foreach (var cell in wand_path)
                 {
-                    wand_pos.y--;
-                    wand_path = LineAlg.GetPointsOnLine(MapManager.playerPos.x, MapManager.playerPos.y, wand_pos.x, wand_pos.y);
-
-                    foreach (var cell in wand_path)
-                    {
-                        MapManager.map[cell.x, cell.y].decoy = $"<color=yellow>\u205C</color>";
-                    }
-
-                    DungeonGenerator.dungeonGenerator.DrawMap(true, MapManager.map);
-                }
-                else if (Input.GetKeyDown(KeyCode.A) && CellIsAvailable(wand_pos.x - 1, wand_pos.y))
-                {
-                    wand_pos.x--;
-                    wand_path = LineAlg.GetPointsOnLine(MapManager.playerPos.x, MapManager.playerPos.y, wand_pos.x, wand_pos.y);
-
-                    foreach (var cell in wand_path)
-                    {
-                        MapManager.map[cell.x, cell.y].decoy = $"<color=yellow>\u205C</color>";
-                    }
-
-                    DungeonGenerator.dungeonGenerator.DrawMap(true, MapManager.map);
-                }
-                else if (Input.GetKeyDown(KeyCode.D) && CellIsAvailable(wand_pos.x + 1, wand_pos.y))
-                {
-                    wand_pos.x++;
-                    wand_path = LineAlg.GetPointsOnLine(MapManager.playerPos.x, MapManager.playerPos.y, wand_pos.x, wand_pos.y);
-
-                    foreach (var cell in wand_path)
-                    {
-                        MapManager.map[cell.x, cell.y].decoy = $"<color=yellow>\u205C</color>";
-                    }
-
-                    DungeonGenerator.dungeonGenerator.DrawMap(true, MapManager.map);
+                    MapManager.map[cell.x, cell.y].decoy = $"<color=yellow>\u205C</color>";
                 }
             }
-            else if(usedWand._spellType == WandSO.spellType.point)
+            else if (usedWand._spellType == WandSO.spellType.point)
             {
-                if (Input.GetKeyDown(KeyCode.W) && CellIsAvailable(wand_pos.x, wand_pos.y + 1))
+                if (!usedWand.AllowTargeting())
                 {
-                    if(MapManager.map[wand_pos.x, wand_pos.y + 1].type != "Wall")
-                    {
-                        wand_pos.y++;
-                        wand_path = LineAlg.GetPointsOnLine(MapManager.playerPos.x, MapManager.playerPos.y, wand_pos.x, wand_pos.y);
-
-                        foreach (var cell in wand_path)
-                        {
-                            MapManager.map[cell.x, cell.y].decoy = $"<color=yellow>\u205C</color>";
-                        }
-                    }                                      
-
-                    DungeonGenerator.dungeonGenerator.DrawMap(true, MapManager.map);
+                    Targeting.Revert();
                 }
-                else if (Input.GetKeyDown(KeyCode.S) && CellIsAvailable(wand_pos.x, wand_pos.y - 1))
+
+                wand_path = LineAlg.GetPointsOnLine(
+                MapManager.playerPos.x, MapManager.playerPos.y,
+                Targeting.Position.x, Targeting.Position.y);
+
+                foreach (var cell in wand_path)
                 {
-                    wand_pos.y--;
-                    wand_path = LineAlg.GetPointsOnLine(MapManager.playerPos.x, MapManager.playerPos.y, wand_pos.x, wand_pos.y);
-
-                    foreach (var cell in wand_path)
-                    {
-                        MapManager.map[cell.x, cell.y].decoy = $"<color=yellow>\u205C</color>";
-                    }
-
-                    DungeonGenerator.dungeonGenerator.DrawMap(true, MapManager.map);
-                }
-                else if (Input.GetKeyDown(KeyCode.A) && CellIsAvailable(wand_pos.x - 1, wand_pos.y))
-                {
-                    wand_pos.x--;
-                    wand_path = LineAlg.GetPointsOnLine(MapManager.playerPos.x, MapManager.playerPos.y, wand_pos.x, wand_pos.y);
-
-                    foreach (var cell in wand_path)
-                    {
-                        MapManager.map[cell.x, cell.y].decoy = $"<color=yellow>\u205C</color>";
-                    }
-
-                    DungeonGenerator.dungeonGenerator.DrawMap(true, MapManager.map);
-                }
-                else if (Input.GetKeyDown(KeyCode.D) && CellIsAvailable(wand_pos.x + 1, wand_pos.y))
-                {
-                    wand_pos.x++;
-                    wand_path = LineAlg.GetPointsOnLine(MapManager.playerPos.x, MapManager.playerPos.y, wand_pos.x, wand_pos.y);
-
-                    foreach (var cell in wand_path)
-                    {
-                        MapManager.map[cell.x, cell.y].decoy = $"<color=yellow>\u205C</color>";
-                    }
-
-                    DungeonGenerator.dungeonGenerator.DrawMap(true, MapManager.map);
+                    MapManager.map[cell.x, cell.y].decoy = $"<color=yellow>\u205C</color>";
                 }
             } //todo
             else
             {
-                usingWand = false;
-                usedWand.UseWandSpell();
-                usedWand = null;
-                PlayerMovement.playerMovement.canMove = true;
+                if (usedWand.IsValidTarget())
+                {
+                    usingWand = false;
+                    Targeting.IsTargeting = false;
+                    usedWand.UseWandSpell();
+                    usedWand = null;
+                    PlayerMovement.playerMovement.canMove = true;
+                }
+                else
+                {
+                    // you cannot target that guys
+                    Debug.Log("not the right target");
+                }
             }
 
             if (Input.GetKeyDown(KeyCode.Return))
             {
-                usingWand = false;
-                usedWand.UseWandSpell();                           
-                usedWand = null;
-                gameManager.ApplyChangesInInventory(null);
-                PlayerMovement.playerMovement.canMove = true;
+                if (usedWand.IsValidTarget())
+                {
+                    usingWand = false;
+                    Targeting.IsTargeting = false;
+                    usedWand.UseWandSpell();
+                    usedWand = null;
+                    gameManager.ApplyChangesInInventory(null);
+                    PlayerMovement.playerMovement.canMove = true;
+                }
+                else
+                {
+                    // you cannot target that guys
+                    Debug.Log("not the right target");
+                }
             }
+            DungeonGenerator.dungeonGenerator.DrawMap(true, MapManager.map);
         }
 
-        if(usingSpellScroll)
+        if (usingSpellScroll)
         {
-            if(PlayerMovement.playerMovement.canMove)
+            if (PlayerMovement.playerMovement.canMove)
             {
-                Debug.Log(MapManager.playerPos + " " + spell_pos);
+                Debug.Log(MapManager.playerPos + " " + Targeting.Position);
                 PlayerMovement.playerMovement.canMove = false;
                 gameManager.UpdateMessages("Choose target of your spell. <color=pink>(Numpad 8 4 6 2, Enter/Space to confirm, Escape to cancel)</color>");
-            } 
-
-            if (Input.GetKeyDown(KeyCode.Keypad8))
-            {
-                if(MapManager.map[spell_pos.x, spell_pos.y + 1].type != "Wall" && MapManager.map[spell_pos.x, spell_pos.y + 1].isExplored)
-                {
-                    spell_pos.y++;
-                    MapManager.map[spell_pos.x, spell_pos.y].decoy = $"<color=yellow>\u205C</color>";
-                }
-                else MapManager.map[spell_pos.x, spell_pos.y].decoy = $"<color=yellow>\u205C</color>";
-                //else spell_pos.y++;
-
-                DungeonGenerator.dungeonGenerator.DrawMap(true, MapManager.map);
             }
-            else if (Input.GetKeyDown(KeyCode.Keypad2))
-            {
-                if (MapManager.map[spell_pos.x, spell_pos.y - 1].type != "Wall" && MapManager.map[spell_pos.x, spell_pos.y - 1].isExplored)
-                {
-                    spell_pos.y--;
-                    MapManager.map[spell_pos.x, spell_pos.y].decoy = $"<color=yellow>\u205C</color>";
-                }
-                else MapManager.map[spell_pos.x, spell_pos.y].decoy = $"<color=yellow>\u205C</color>";
 
-                DungeonGenerator.dungeonGenerator.DrawMap(true, MapManager.map);
-            }
-            else if (Input.GetKeyDown(KeyCode.Keypad4))
-            {
-                if (MapManager.map[spell_pos.x - 1, spell_pos.y].type != "Wall" && MapManager.map[spell_pos.x - 1, spell_pos.y].isExplored)
-                {
-                    spell_pos.x--;
-                    MapManager.map[spell_pos.x, spell_pos.y].decoy = $"<color=yellow>\u205C</color>";
-                }
-                else MapManager.map[spell_pos.x, spell_pos.y].decoy = $"<color=yellow>\u205C</color>";
 
-                DungeonGenerator.dungeonGenerator.DrawMap(true, MapManager.map);
-            }
-            else if (Input.GetKeyDown(KeyCode.Keypad6))
-            {
-                if (MapManager.map[spell_pos.x + 1, spell_pos.y].type != "Wall" && MapManager.map[spell_pos.x + 1, spell_pos.y].isExplored)
-                {
-                    spell_pos.x++;
-                    MapManager.map[spell_pos.x, spell_pos.y].decoy = $"<color=yellow>\u205C</color>";
-                }
-                else MapManager.map[spell_pos.x, spell_pos.y].decoy = $"<color=yellow>\u205C</color>";
 
-                DungeonGenerator.dungeonGenerator.DrawMap(true, MapManager.map);
-            } //todo
+
+            MapManager.map[Targeting.Position.x, Targeting.Position.y].decoy = $"<color=yellow>\u205C</color>";
+            DungeonGenerator.dungeonGenerator.DrawMap(true, MapManager.map);
 
             if (Input.GetButtonDown("Use"))
             {
-                PlayerMovement.playerMovement.canMove = true;
-
-                usingSpellScroll = false;
-                if(usedScrollOrBook is ScrollSO scroll)
+                if (usedScrollOrBook is IRestrictTargeting target)
                 {
-                    scroll.UseSpell(this);
-                }     
-                else if(usedScrollOrBook is SpellbookSO book)         
-                {
-                    book.UseSpell(this);
-                }         
-                usedScrollOrBook = null;
-                gameManager.ApplyChangesInInventory(null);
+                    if (target.IsValidTarget())
+                    {
+                        PlayerMovement.playerMovement.canMove = true;
+                        Targeting.IsTargeting = false;
+                        usingSpellScroll = false;
+                        if (usedScrollOrBook is ScrollSO scroll)
+                        {
+                            scroll.UseSpell(this);
+                        }
+                        else if (usedScrollOrBook is SpellbookSO book)
+                        {
+                            book.UseSpell(this);
+                        }
+                        usedScrollOrBook = null;
+                        gameManager.ApplyChangesInInventory(null);
+                    }
+                }
+                DungeonGenerator.dungeonGenerator.DrawMap(true, MapManager.map);
             }
-            if(Input.GetKeyDown(KeyCode.Escape))
+            if (Input.GetKeyDown(KeyCode.Escape))
             {
                 PlayerMovement.playerMovement.canMove = true;
+                Targeting.IsTargeting = false;
                 usingSpellScroll = false;
                 usedScrollOrBook = null;
+                DungeonGenerator.dungeonGenerator.DrawMap(true, MapManager.map);
             }
         }
     

--- a/Tower/AsciiRogue/Assets/Scripts/Targeting.cs
+++ b/Tower/AsciiRogue/Assets/Scripts/Targeting.cs
@@ -1,0 +1,151 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class Targeting
+{
+    private static bool _isTargeting;
+
+
+    public static bool IsTargeting
+    {
+        get
+        {
+            return _isTargeting;
+        }
+        set
+        {
+            if (_isTargeting!=value)
+            {
+                if (value)
+                {
+                    // enable
+                    StartTargeting();
+                }
+                else
+                {
+                    // disable
+                    StopTargeting();
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// determins if the Targeting is allowed to target places that have not been explored
+    /// </summary>
+    public static bool RequireDiscovery;
+    /// <summary>
+    /// determins how far the targeting can go. -1 will allow for unlimited range
+    /// </summary>
+    public static int MaxRange = -1;
+
+    /// <summary>
+    /// the current position of targeting
+    /// </summary>
+    public static Vector2Int Position;
+
+    /// <summary>
+    /// the previous position of targeting
+    /// </summary>
+    private static Vector2Int LastPosition;
+    private static Vector2Int changePosition;
+    /// <summary>
+    /// initializes the targeting to be fresh
+    /// </summary>
+    public static void StartTargeting()
+    {
+        _isTargeting = true;
+        Position = PlayerMovement.playerMovement.position;
+    }
+    /// <summary>
+    /// Disables targeting, preserves Values
+    /// </summary>
+    public static void StopTargeting()
+    {
+        _isTargeting = false;
+        MaxRange = -1;
+    }
+    /// <summary>
+    /// revert the changes done in the last update, if a targeting is not valid
+    /// </summary>
+    public static void Revert()
+    {
+        Position = LastPosition;
+    }
+    
+    public static void UpdateTargeting()
+    {
+        if (IsTargeting)
+        {
+            changePosition = Position;
+            if (PlayerMovement.playerMovement.canMove) PlayerMovement.playerMovement.canMove = false;
+
+            if ((Input.GetKeyDown(KeyCode.W) ||Input.GetKeyDown( KeyCode.Keypad8))&& CellIsAvailable(Position.x, Position.y + 1))
+            {
+                MoveTargeting(0, 1);
+            }
+            else if ((Input.GetKeyDown(KeyCode.S) || Input.GetKeyDown(KeyCode.Keypad2)) && CellIsAvailable(Position.x, Position.y - 1))
+            {
+                MoveTargeting(0, -1);
+            }
+            else if ((Input.GetKeyDown(KeyCode.A) || Input.GetKeyDown(KeyCode.Keypad4)) && CellIsAvailable(Position.x - 1, Position.y))
+            {
+                MoveTargeting(-1, 0);
+            }
+            else if ((Input.GetKeyDown(KeyCode.D) || Input.GetKeyDown(KeyCode.Keypad6)) && CellIsAvailable(Position.x + 1, Position.y))
+            {
+                MoveTargeting(1, 0);
+            }
+            else if ( Input.GetKeyDown(KeyCode.Keypad1) && CellIsAvailable(Position.x -1, Position.y -1))
+            {
+                MoveTargeting(-1,-1);
+            }
+            else if ( Input.GetKeyDown(KeyCode.Keypad3) && CellIsAvailable(Position.x + 1, Position.y - 1))
+            {
+                MoveTargeting(1, -1);
+            }
+            else if ( Input.GetKeyDown(KeyCode.Keypad9) && CellIsAvailable(Position.x + 1, Position.y + 1))
+            {
+                MoveTargeting(1, 1);
+            }
+            else if (Input.GetKeyDown(KeyCode.Keypad7) && CellIsAvailable(Position.x - 1, Position.y + 1))
+            {
+                MoveTargeting(-1, 1);
+            }
+            if (changePosition!=Position)
+            {
+                LastPosition = changePosition;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Moves the targeting to a different position
+    /// </summary>
+    /// <param name="dx">delta X</param>
+    /// <param name="dy">delta Y</param>
+    /// <returns>returns the new targeting position</returns>
+    public static void MoveTargeting(int dx, int dy)
+    {
+        Position = Position + new Vector2Int(dx, dy);
+    }
+    /// <summary>
+    /// checks a cell for being not wall or door that is stopping us
+    /// </summary>
+    /// <param name="x">global X position</param>
+    /// <param name="y">global Y position</param>
+    /// <returns>if the cell is available</returns>
+    private static bool CellIsAvailable(int x, int y)
+    {
+        return MapManager.map[x, y].type != "Wall"
+            && MapManager.map[x, y].type != "Door"
+            && y > 0
+            && y < DungeonGenerator.dungeonGenerator.mapHeight
+            && x > 0
+            && x < DungeonGenerator.dungeonGenerator.mapWidth
+            && (Vector2Int.Distance(MapManager.playerPos, new Vector2Int(x, y)) < MaxRange || MaxRange == -1);
+    }
+    
+
+}

--- a/Tower/AsciiRogue/Assets/Scripts/Targeting.cs.meta
+++ b/Tower/AsciiRogue/Assets/Scripts/Targeting.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 53ca7256967ae024997fbe0c9aa6347d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
I am done with Targeting. 
I only need to make the selector use it, else everything now uses the new class.
Targeting is automatically updated (inside Playerstats)
there are parameters you can set for targeting: max Range, requireDiscovery(if you can target something you haven't explored yet)
these can be set as Targeting.<parameter> = <value>;
if you want to check if something is currently targeting use Targeting.IsTargeting
to start targeting just set Targeting.IsTargeting = true;
It will then start tracking user input.
Targeting is now controlled using the Numpad as default. (WASD can still be used tho)
Targeting does NOT automatically draw stuff that is still on whoever wants to use it.
e.g.:

      if (usingWand)
      {
         if (usedWand._spellType == WandSO.spellType.ray)
         {
            if (!usedWand.AllowTargeting())
            {
               Targeting.Revert();
            }
            wand_path = LineAlg.GetPointsOnLine(
            MapManager.playerPos.x, MapManager.playerPos.y,
            Targeting.Position.x, Targeting.Position.y);
            foreach (var cell in wand_path)
            {
               MapManager.map[cell.x, cell.y].decoy = $"<color=yellow>\u205C</color>";
            }
         }
      }


WandSO, ScrollSO & SpellbookSO no implement IRestrictTargeting
This interface should be used to control the Targeting from the outside
AllowTargeting should be used to check if the current spot or last move is allowed (check line of sight or something)
if not allowed, you can use the Targeting.Revert() method to revert to the last position

The IsValidTarget() method should be used to check if whatever is currently targeted should be allowed to be targeted 
things like "this spell is only castable on undead" or something like that

Targeting.Position will give the current targeting position (who would have guessed)

Turn of targeting by setting Targeting.IsTargeting = false