### PR TITLE
Popup system now working

### DIFF
--- a/Tower/AsciiRogue/Assets/Scenes/Scene 0.unity
+++ b/Tower/AsciiRogue/Assets/Scenes/Scene 0.unity
@@ -296,7 +296,6 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1927692413}
-  - {fileID: 874567765}
   m_Father: {fileID: 790067056}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3712,6 +3711,7 @@ RectTransform:
   - {fileID: 27060434}
   - {fileID: 1134536924}
   - {fileID: 1159816762}
+  - {fileID: 874567765}
   m_Father: {fileID: 1467341619}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -4283,12 +4283,12 @@ RectTransform:
   m_Children:
   - {fileID: 827296974}
   - {fileID: 463673545}
-  m_Father: {fileID: 27060434}
-  m_RootOrder: 1
+  m_Father: {fileID: 790067056}
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 3.4999866}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &879053186

--- a/Tower/AsciiRogue/Assets/Scripts/Controls/Controls.cs
+++ b/Tower/AsciiRogue/Assets/Scripts/Controls/Controls.cs
@@ -39,6 +39,7 @@ public static class Controls
         InventoryChoice1,
         InventoryChoice2,
         InventoryChoice3,
+        InventoryChoice4,
 
         SkillsOpen,
         SkillsUp,
@@ -86,6 +87,7 @@ public static class Controls
         { Inputs.InventoryChoice1.ToString(),KeyCode.Alpha1},
         { Inputs.InventoryChoice2.ToString(),KeyCode.Alpha2},
         { Inputs.InventoryChoice3.ToString(),KeyCode.Alpha3},
+        { Inputs.InventoryChoice4.ToString(),KeyCode.Alpha4},
 
         { Inputs.SkillsUp.ToString(),KeyCode.Alpha8},
         { Inputs.SkillsDown.ToString(),KeyCode.Alpha2},

--- a/Tower/AsciiRogue/Assets/Scripts/GameManager.cs
+++ b/Tower/AsciiRogue/Assets/Scripts/GameManager.cs
@@ -60,8 +60,6 @@ public class GameManager : MonoBehaviour
     [Header("Decisions")]
     public Text decisions;
     public GameObject GOdec;
-    private bool decisionMade;
-    private bool deciding;
     //private ItemScriptableObject _iso;
     private Item _selectedItem;
     private bool equipState;
@@ -113,6 +111,8 @@ public class GameManager : MonoBehaviour
     [HideInInspector] public bool anvilMenuOpened;
     [HideInInspector] public Anvil anvil;
 
+    public bool MenuOpen => anvilMenuOpened || openGrimoire || inventoryOpen || SkillsOpen ||IsThrowingItem;
+
     void Awake()
     {
         if (!Controls.IsInitialized)
@@ -122,6 +122,8 @@ public class GameManager : MonoBehaviour
         fv = GetComponent<FOVNEW>();
 
         manager = this;
+
+        Popup.Init(GOdec, decisions);
 
         m_Messages = new Queue();
         m_Inventory = new Queue<string>();
@@ -233,7 +235,7 @@ public class GameManager : MonoBehaviour
                 CloseEQ();
             }
 
-            if (inventoryOpen)
+            if (inventoryOpen && !Popup.Showing)
             {
                 if (Controls.GetKeyDown(Controls.Inputs.Use) && !choosingWeapon)
                 {
@@ -249,87 +251,77 @@ public class GameManager : MonoBehaviour
                     if (anvilMenuOpened)
                     {
                         if(_selectedItem.iso.I_itemType == ItemScriptableObject.itemType.Armor || _selectedItem.iso.I_itemType == ItemScriptableObject.itemType.Weapon)
-                        {
-                            itemOption1 = "";
-                            itemOption2 = "";
-                            itemOption3 = "";
-                            itemOption4 = "";
-                            itemOption5 = "";
-
-                            decisionsCount = 1;
+                        {                            
                             equipState = playerStats.itemsInEqGO[selectedItem].isEquipped;
-
-                            GOdec.SetActive(true);
-
-                            decisions.text += "1. Anvil";
-                            AddAnotherOption("Upgrade");
-
-                            decisionMade = false;
-                            deciding = true;
+                                                       
+                            Popup.NewDecission(true, ("Anvil", "Upgrade", gameObject));
+                            Popup.Show();
 
                             DecisionTurn();
                         }                       
                     }
                     else
                     {
-                        itemOption1 = "";
-                        itemOption2 = "";
-                        itemOption3 = "";
-                        itemOption4 = "";
-                        itemOption5 = "";
-
-                        decisionsCount = 1;
                         equipState = playerStats.itemsInEqGO[selectedItem].isEquipped;
 
-                        GOdec.SetActive(true);
+                        //GOdec.SetActive(true);
 
-                        decisions.text = "1. Drop";
-                        AddAnotherOption("Drop");
+                        Popup.NewDecission();
+                        Popup.AddDecissionOption("Drop", "Drop", gameObject);
+                        //decisions.text = "1. Drop";
+                        //AddAnotherOption("Drop");
 
                         if (_selectedItem.iso.I_whereToPutIt != ItemScriptableObject.whereToPutIt.none)
                         {
                             if (equipState == true)
                             {
-                                decisions.text += "\n" + "2. Unequip";
-                                decisionsCount++;
-                                AddAnotherOption("UEquip");
+                                Popup.AddDecissionOption("Unequip", "UEquip", gameObject);
+                                //decisions.text += "\n" + "2. Unequip";
+                                //decisionsCount++;
+                                //AddAnotherOption("UEquip");
                             }
                             else
                             {
-                                decisions.text += "\n" + "2. Equip";
-                                decisionsCount++;
-                                AddAnotherOption("UEquip");
+                                Popup.AddDecissionOption("Equip", "UEquip", gameObject);
+                                //decisions.text += "\n" + "2. Equip";
+                                //decisionsCount++;
+                                //AddAnotherOption("UEquip");
                             }
                         }
                         if (_selectedItem.iso.I_itemType == ItemScriptableObject.itemType.Wand || _selectedItem.iso.I_itemType == ItemScriptableObject.itemType.Scroll || _selectedItem.iso.I_itemType == ItemScriptableObject.itemType.Spellbook || _selectedItem.iso.I_itemType == ItemScriptableObject.itemType.Gem || _selectedItem.iso is Bell bell)
                         {
-                            decisionsCount++;
-                            decisions.text += "\n" + decisionsCount + ". " + "Use";
-                            AddAnotherOption("Use");
+                            Popup.AddDecissionOption("Use", "Use", gameObject);
+                            //decisionsCount++;
+                            //decisions.text += "\n" + decisionsCount + ". " + "Use";
+                            //AddAnotherOption("Use");
                         }
                         else if (_selectedItem.iso.I_itemType == ItemScriptableObject.itemType.Potion)
                         {
-                            decisionsCount++;
-                            decisions.text += "\n" + decisionsCount + ". " + "Drink";
-                            AddAnotherOption("Use");
+                            Popup.AddDecissionOption("Drink", "Use", gameObject);
+                            //decisionsCount++;
+                            //decisions.text += "\n" + decisionsCount + ". " + "Drink";
+                            //AddAnotherOption("Use");
                         }
                         else if(_selectedItem.iso.I_itemType == ItemScriptableObject.itemType.Readable)
                         {
-                            decisionsCount++;
-                            decisions.text += "\n" + decisionsCount + ". " + "Read";
-                            AddAnotherOption("Use");
+                            Popup.AddDecissionOption("Read", "Use", gameObject);
+                            //decisionsCount++;
+                            //decisions.text += "\n" + decisionsCount + ". " + "Read";
+                            //AddAnotherOption("Use");
                         }
                         if (!equipState && ItemThrowHelper.CanBeThrown(_selectedItem))
                         {
-                            decisionsCount++;
-                            decisions.text += "\n" + decisionsCount + ". Throw";
-                            AddAnotherOption("ThrowItem");
+                            Popup.AddDecissionOption("Throw", "ThrowItem", gameObject);
+                            //decisionsCount++;
+                            //decisions.text += "\n" + decisionsCount + ". Throw";
+                            //AddAnotherOption("ThrowItem");
                         }
 
-                        decisionMade = false;
-                        deciding = true;
+                        //decisionMade = false;
+                        //deciding = true;
 
-                        DecisionTurn();
+                        //DecisionTurn();
+                        Popup.Show();
                     }                                     
                 }
                 /*else if(Controls.GetKeyDown(Controls.Inputs.Use) && choosingWeapon && playerStats.itemsInEqGO[selectedItem].iso is WeaponsSO) //ADD GEM TO THE SOCKET
@@ -553,7 +545,7 @@ public class GameManager : MonoBehaviour
                 MapManager.NeedRepaint = true;
             }
         }
-        
+
         /*if(decidingSpell)
         {
             if (Controls.GetKeyDown(Controls.Inputs.InventoryChoice1))
@@ -566,6 +558,22 @@ public class GameManager : MonoBehaviour
             }
         }*/
 
+        if (Popup.Showing)
+        {
+            if (Popup.CheckDecission())
+            {
+                // the user clicked something
+                
+                // FinishPlayersTurn();
+            }
+            else
+            {
+                // the user didnt click anything
+            }
+        }
+
+
+        /*
         if (deciding && !choosingWeapon)
         {
             if (Controls.GetKeyDown(Controls.Inputs.InventoryChoice1)) //drop item
@@ -596,14 +604,17 @@ public class GameManager : MonoBehaviour
                 FinishPlayersTurn();
             }
         }
-        
+        */
+
+        /*
         if (decisionMade)   
         {
             deciding = false;
             decidingSpell = false;
             GOdec.SetActive(false);            
         }
-        
+        */
+
         if (playerStats.isDead)
         {
             dungeonGenerator.screen.text = playerStats.deadText;
@@ -676,29 +687,6 @@ public class GameManager : MonoBehaviour
         }
     }
 
-    public void AddAnotherOption(string option)
-    {
-        if(itemOption1 == "")
-        {
-            itemOption1 = option;
-        }
-        else if(itemOption2 == "")
-        {
-            itemOption2 = option;
-        }
-        else if (itemOption3 == "")
-        {
-            itemOption3 = option;
-        }
-        else if (itemOption4 == "")
-        {
-            itemOption4 = option;
-        }
-        else if (itemOption5 == "")
-        {
-            itemOption5 = option;
-        }
-    }
 
     public IEnumerator DestroyTorchEffect(Vector2Int _pos)
     {
@@ -756,7 +744,6 @@ public class GameManager : MonoBehaviour
         if (_selectedItem.cursed && _selectedItem.equippedPreviously)
         {
             UpdateMessages("You can't drop this item because it is <color=red>cursed</color>!");
-            decisionMade = true;
             FinishPlayersTurn();
             return;
         }
@@ -779,7 +766,6 @@ public class GameManager : MonoBehaviour
         else
         {
             UpdateMessages("There is no space around you.");
-            decisionMade = true;
             FinishPlayersTurn();
             return;
         }
@@ -789,7 +775,6 @@ public class GameManager : MonoBehaviour
             if (GetComponent<RevivingMonster>().TestRevive(MapManager.playerPos, _selectedItem))
             {
                 UpdateInventoryText();
-                decisionMade = true;
                 FinishPlayersTurn();
                 ApplyChangesInInventory(_selectedItem.iso);
                 return;
@@ -892,7 +877,6 @@ public class GameManager : MonoBehaviour
             }
         }
 
-        decisionMade = true;
         FinishPlayersTurn();
     }
 
@@ -1107,8 +1091,6 @@ public class GameManager : MonoBehaviour
                 }
                 UpdateInventoryText();
             }
-
-            decisionMade = true;
             FinishPlayersTurn();
         }
         else
@@ -1118,14 +1100,11 @@ public class GameManager : MonoBehaviour
                 gemToConnect = _selectedItem.iso;
                 UpdateMessages("Choose weapon. (ESC to cancel)");
                 choosingWeapon = true;
-                decisionMade = true;
             }
             else
             {
                 _selectedItem.iso.Use(playerStats, _selectedItem);
                 ApplyChangesInInventory(null);
-
-                decisionMade = true;
                 FinishPlayersTurn();
             }
         }
@@ -1138,7 +1117,6 @@ public class GameManager : MonoBehaviour
             gemToConnect = _selectedItem.iso;
             UpdateMessages("Choose weapon.");
             choosingWeapon = true;
-            decisionMade = true;
         }
         else
         {
@@ -1152,9 +1130,7 @@ public class GameManager : MonoBehaviour
             if (playerStats.isBlind && _selectedItem.iso is ScrollSO scr || _selectedItem.iso is SpellbookSO spl)
             {
                 ApplyChangesInInventory(null);
-
-                decisionMade = true;
-
+                
                 FinishPlayersTurn();
             }
             else
@@ -1164,9 +1140,7 @@ public class GameManager : MonoBehaviour
                 UpdateItemStats(_selectedItem);
 
                 ApplyChangesInInventory(null);
-
-                decisionMade = true;
-
+                
                 FinishPlayersTurn();
             }
         }
@@ -1193,7 +1167,6 @@ public class GameManager : MonoBehaviour
         CloseEQ();
         Targeting.IsTargeting = true;
         IsThrowingItem = true;
-        decisionMade = true;
         ItemThrowHelper.PrepareItem(playerStats,_selectedItem);
         UpdateMessages("Choose a target for the throw");
     }
@@ -1202,7 +1175,6 @@ public class GameManager : MonoBehaviour
     {
         itemToAnvil = _selectedItem.GetComponent<Item>();
         anvil.UseAnvil();
-        decisionMade = true;
     }
 
     bool CanItemBeDroppedHere(Vector2Int pos)

--- a/Tower/AsciiRogue/Assets/Scripts/Popup.meta
+++ b/Tower/AsciiRogue/Assets/Scripts/Popup.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 38f99b19190e93e4e90f61b0d40bc1cf
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tower/AsciiRogue/Assets/Scripts/Popup/Popup.cs
+++ b/Tower/AsciiRogue/Assets/Scripts/Popup/Popup.cs
@@ -1,0 +1,204 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class Popup
+{
+
+    public static bool Showing { get; private set; } = false;
+
+    static Dictionary<Controls.Inputs, (bool showNumber,string DisplayName,System.Action callback)> responds;
+
+    public static Status LastStatus { get; private set; } = Status.Closed;
+
+    public static GameObject RootPopup;
+
+    public static UnityEngine.UI.Text Text;
+
+    public static bool CanCancel = true;
+
+    private static KeyValuePair<Controls.Inputs, (bool showNumber, string DisplayName, System.Action callback)> lastInput;
+    public static KeyValuePair<Controls.Inputs, (bool showNumber, string DisplayName, System.Action callback)> LastInput => lastInput;
+
+    public enum Status
+    {
+        Waiting,
+        Closed,
+        Canceled
+    }
+
+    public static void Init(GameObject rootPopup, UnityEngine.UI.Text txt)
+    {
+        RootPopup = rootPopup;
+        Text = txt;
+    }
+
+    /// <summary>
+    /// Configures a new Text Popup which can be closed by pressing the <see cref="Controls.Inputs.Use"/> key
+    /// </summary>
+    /// <param name="text">The text to display</param>
+    /// <param name="callbackName">The name of the method that should be called when confirmed</param>
+    /// <param name="target">On what object the method should be called</param>
+    public static void NewTextConfirmation(string text,  string callbackName, GameObject target,bool canCancel = true)
+    {
+        ClearResponds();
+        CanCancel = canCancel;
+
+        AddResponds(Controls.Inputs.Use, (false, text, () => { target.SendMessage(callbackName); }));
+
+    }
+    public static void NewTextConfirmation(string text, System.Action callback, bool canCancel = true)
+    {
+        ClearResponds();
+        CanCancel = canCancel;
+
+        AddResponds(Controls.Inputs.Use, (false, text, callback));
+    }
+
+    public static void NewDecission()
+    {
+        ClearResponds();
+        CanCancel = true;
+    }
+    public static void NewDecission(bool canCancel, params (string desc, string callbackName,GameObject target )[] entries)
+    {
+        ClearResponds();
+        CanCancel = canCancel;
+        for (int i = 0; i < entries.Length; i++)
+        {
+            var t = entries[i];
+            Controls.Inputs btn = NextInventoryChoice();
+            
+            AddResponds(btn, (true, t.desc, () => t.target.SendMessage(t.callbackName)));
+        }
+    }
+    public static void NewDecission(bool canCancel, params (string desc, System.Action callback)[] entries)
+    {
+        ClearResponds();
+        CanCancel = canCancel;
+        for (int i = 0; i < entries.Length; i++)
+        {
+            var t = entries[i];
+            Controls.Inputs btn = NextInventoryChoice();
+            AddResponds(btn, (true, t.desc, t.callback));
+        }
+
+    }
+
+    private static Controls.Inputs NextInventoryChoice()
+    {
+        switch (responds.Count)
+        {
+            case 0:
+                return Controls.Inputs.InventoryChoice1;
+            case 1:
+                return Controls.Inputs.InventoryChoice2;
+            case 2:
+                return Controls.Inputs.InventoryChoice3;
+            case 3:
+                return Controls.Inputs.InventoryChoice4;
+            default:
+                return Controls.Inputs.Use;
+        }
+    }
+    public static void AddDecissionOption(string desc, System.Action callback)
+    {
+        Controls.Inputs btn = NextInventoryChoice();
+        AddResponds(btn, (true, desc, callback));
+    }
+    public static void AddDecissionOption(string desc, string callbackName, GameObject target)
+    {
+        Controls.Inputs btn = NextInventoryChoice();
+        AddResponds(btn, (true, desc, ()=>target.SendMessage(callbackName)));
+    }
+    private static void AddResponds(Controls.Inputs input, (bool showNumber, string DisplayName, System.Action callback) data)
+    {
+        responds.Add(input, data);
+    }
+
+    private static void ClearResponds()
+    {
+        CanCancel = true;
+        if (responds==null)
+        {
+            responds = new Dictionary<Controls.Inputs, (bool showNumber, string DisplayName, System.Action callback)>();
+        }
+        responds.Clear();
+    }
+
+    private static void UpdateText()
+    {
+        int num = 1;
+        Text.text = "";
+        foreach (var item in responds)
+        {
+            if (item.Value.DisplayName!=string.Empty)
+            {
+                if (num > 1)
+                {
+                    Text.text += "\n";
+                }
+                if (item.Value.showNumber)
+                {
+                    Text.text += num + ". ";
+                }
+                Text.text += item.Value.DisplayName;
+            }
+            num++;
+        }
+    }
+    public static void Show()
+    {
+        UpdateText();
+        RootPopup.SetActive(true);
+        Showing = true;
+        LastStatus = Status.Waiting;        
+    }
+    public static void Hide(bool cancel = false)
+    {
+        RootPopup.SetActive(false);
+        Showing = false;
+        if (cancel)
+        {
+            LastStatus = Status.Canceled;
+        }
+        else
+        {
+            LastStatus = Status.Closed;
+        }        
+    }
+
+    /// <summary>
+    /// check if a decission was made
+    /// </summary>
+    /// <returns>true if decission was made</returns>
+    public static bool CheckDecission()
+    {
+        if (Showing)
+        {
+            if (CanCancel && Controls.GetKeyDown(Controls.Inputs.CancelButton))
+            {
+                // we cancel the popup
+                Hide(true);
+                lastInput = default;
+                return true;
+            }
+
+            foreach (var entry in responds)
+            {
+                if (Controls.GetKeyDown(entry.Key))
+                {
+                    // the use did an input
+                    Hide();
+                    entry.Value.callback?.Invoke();
+                    lastInput = entry;                    
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+
+
+}

--- a/Tower/AsciiRogue/Assets/Scripts/Popup/Popup.cs.meta
+++ b/Tower/AsciiRogue/Assets/Scripts/Popup/Popup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 46c6a75db3b9f1e4fb31b9de244e1fda
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The Popup System:
Popup is a static class which provides a way of showing a popup to the player where the player can choose something or can only confirm.

Usage: (Decission)
the popup system supports the decission option functionality of the inventory (used for choosing "throw", "use", etc.
The workflow for the Popup is the flollowing:
- Call Popup.NewDecission and provide some parameters if you want
- you can add additional decission by calling Popup.AddDecissionOption
- transition into the Popup by calling Popup.Show()

Therere is also a new TextConfirmation Popup. Which will display a text and can be closed with the "Use" key. (or canceled with the cancel key if enabled)

Something important: Popup privides a Property called Popup.Showing which can be used to see if the Popup is shown. (example: moving in inventory while popup is there) so there might need to be some additions for that.

Also: There is now a Property in GameManager called "MenuOpen" which returns true if any Menu is open (anvil, inventory, grimoire, skills/technic,...); can also be used

Finally: Added a new Input for InventoryChoice4 so we can currently have 4 different choices in a Popup Decission